### PR TITLE
v1.2.6 Phase 2B: Add notification strings to src/main/java lang files

### DIFF
--- a/src/main/java/com/aegisguard/lang/hybrid_english/system.yml
+++ b/src/main/java/com/aegisguard/lang/hybrid_english/system.yml
@@ -95,6 +95,24 @@ claim_notify_state_enabled: '&aEnabled'
 claim_notify_state_disabled: '&cDisabled'
 
 # ------------------------------------------------------------
+# ✅ v1.2.6: Enhanced Notification System
+# ------------------------------------------------------------
+notify_unavailable: '&cNotification system is unavailable at this time.'
+notify_greetings_enabled: '&a✔ Greetings enabled. Thou shalt see claim entry and exit messages.'
+notify_greetings_disabled: '&c✔ Greetings disabled. Thou shalt not see claim entry and exit messages.'
+notify_admin_enabled: '&a✔ Admin notifications enabled. Thou wilt receive administrative updates.'
+notify_admin_disabled: '&c✔ Admin notifications disabled. Administrative updates are now hidden.'
+notify_mode_set: '&a✔ Notification mode set to: {MODE}'
+notify_mode_usage: '&eUsage: &7/aegis notify mode <chat|actionbar|title>\n&7Available modes:\n&7- &bchat &8- &7Standard chat messages\n&7- &bactionbar &8- &7Action bar notifications (above hotbar)\n&7- &btitle &8- &7Title/subtitle notifications (center screen)'
+notify_mode_invalid: '&cInvalid mode: &7{MODE}\n&eValid modes: &7chat, actionbar, title'
+notify_status: '&e&l━━━━━━━━━ &6Notification Settings &e&l━━━━━━━━━\n&7Greetings: {GREETINGS}\n&7Admin Updates: {ADMIN}\n&7Mode: {MODE}\n&e&l━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+notify_usage: '&eNotification Commands:\n&7/aegis notify &8- &7Toggle greeting messages\n&7/aegis notify greetings &8- &7Toggle claim entry/exit messages\n&7/aegis notify admin &8- &7Toggle admin notifications\n&7/aegis notify mode <chat|actionbar|title> &8- &7Set notification style\n&7/aegis notify status &8- &7View current settings'
+
+# RolesGUI v1.2.6: Safety Messages
+role_cannot_remove_self: '&c❌ Thou cannot remove thyself as the plot owner. Transfer ownership first.'
+role_no_permission: '&c❌ Thou hast not permission to modify this member.'
+
+# ------------------------------------------------------------
 # Snapshots (Admin tools)
 # Used by: SnapshotAdminGUI
 # ------------------------------------------------------------

--- a/src/main/java/com/aegisguard/lang/modern_english/system.yml
+++ b/src/main/java/com/aegisguard/lang/modern_english/system.yml
@@ -35,6 +35,22 @@ claim_notify_status: '&7Claim enter/exit notifications: &f{STATE}&7.'
 claim_notify_state_enabled: '&aEnabled'
 claim_notify_state_disabled: '&cDisabled'
 
+# ✅ v1.2.6: Enhanced Notification System
+notify_unavailable: '&cNotification system is unavailable at this time.'
+notify_greetings_enabled: '&a✔ Greetings enabled. You will now see claim entry and exit messages.'
+notify_greetings_disabled: '&c✔ Greetings disabled. You will no longer see claim entry and exit messages.'
+notify_admin_enabled: '&a✔ Admin notifications enabled. You will now receive administrative updates.'
+notify_admin_disabled: '&c✔ Admin notifications disabled. Administrative updates are now hidden.'
+notify_mode_set: '&a✔ Notification mode set to: {MODE}'
+notify_mode_usage: '&eUsage: &7/aegis notify mode <chat|actionbar|title>\n&7Available modes:\n&7- &bchat &8- &7Standard chat messages\n&7- &bactionbar &8- &7Action bar notifications (above hotbar)\n&7- &btitle &8- &7Title/subtitle notifications (center screen)'
+notify_mode_invalid: '&cInvalid mode: &7{MODE}\n&eValid modes: &7chat, actionbar, title'
+notify_status: '&e&l━━━━━━━━━ &6Notification Settings &e&l━━━━━━━━━\n&7Greetings: {GREETINGS}\n&7Admin Updates: {ADMIN}\n&7Mode: {MODE}\n&e&l━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+notify_usage: '&eNotification Commands:\n&7/aegis notify &8- &7Toggle greeting messages\n&7/aegis notify greetings &8- &7Toggle claim entry/exit messages\n&7/aegis notify admin &8- &7Toggle admin notifications\n&7/aegis notify mode <chat|actionbar|title> &8- &7Set notification style\n&7/aegis notify status &8- &7View current settings'
+
+# RolesGUI v1.2.6: Safety Messages
+role_cannot_remove_self: '&c❌ You cannot remove yourself as the plot owner. Transfer ownership first.'
+role_no_permission: '&c❌ You do not have permission to modify this member.'
+
 sound_global_enabled: '&a✔ AegisGuard sounds have been enabled.'
 sound_global_disabled: '&c✖ AegisGuard sounds have been disabled.'
 wand_given: '&a⚡ You have received the Aegis Scepter.'

--- a/src/main/java/com/aegisguard/lang/old_english/system.yml
+++ b/src/main/java/com/aegisguard/lang/old_english/system.yml
@@ -133,6 +133,24 @@ claim_notify_target_not_found: '&cPlayer not found.'
 claim_notify_usage: '&cUsage: /aegis notify [on|off|toggle] [player]'
 
 # -------------------------------------------------
+# ✅ v1.2.6: Enhanced Notification System
+# -------------------------------------------------
+notify_unavailable: '&cNotification system is unavailable at this time.'
+notify_greetings_enabled: '&a✔ Greetings enabled. Þū shalt sēon clǣm in-gang and ūt-gang tīdinga.'
+notify_greetings_disabled: '&c✔ Greetings disabled. Þū ne shalt sēon clǣm in-gang and ūt-gang tīdinga.'
+notify_admin_enabled: '&a✔ Admin notifications enabled. Þū wilt onfōn ealdor-man tīdinga.'
+notify_admin_disabled: '&c✔ Admin notifications disabled. Ealdor-man tīdinga sind nū hȳded.'
+notify_mode_set: '&a✔ Notification mode set tō: {MODE}'
+notify_mode_usage: '&eUsage: &7/aegis notify mode <chat|actionbar|title>\n&7Available modes:\n&7- &bchat &8- &7Standard chat messages\n&7- &bactionbar &8- &7Action bar notifications (above hotbar)\n&7- &btitle &8- &7Title/subtitle notifications (center screen)'
+notify_mode_invalid: '&cInvalid mode: &7{MODE}\n&eValid modes: &7chat, actionbar, title'
+notify_status: '&e&l━━━━━━━━━ &6Notification Settings &e&l━━━━━━━━━\n&7Greetings: {GREETINGS}\n&7Admin Updates: {ADMIN}\n&7Mode: {MODE}\n&e&l━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+notify_usage: '&eNotification Commands:\n&7/aegis notify &8- &7Toggle greeting messages\n&7/aegis notify greetings &8- &7Toggle clǣm in-gang/ūt-gang messages\n&7/aegis notify admin &8- &7Toggle ealdor-man notifications\n&7/aegis notify mode <chat|actionbar|title> &8- &7Set notification style\n&7/aegis notify status &8- &7View current settings'
+
+# RolesGUI v1.2.6: Safety Messages
+role_cannot_remove_self: '&c❌ Þū cannot forþierran þyself as þe plot hlāford. Transfer ownership first.'
+role_no_permission: '&c❌ Þū hast not permission tō geændian þis member.'
+
+# -------------------------------------------------
 # Protection Denies
 # -------------------------------------------------
 cannot_break: '&c❌ Thou cannot break blocks here; this area is protected.'

--- a/src/main/java/com/aegisguard/lang/spanish_ar/system.yml
+++ b/src/main/java/com/aegisguard/lang/spanish_ar/system.yml
@@ -147,6 +147,24 @@ claim_notify_status: '&7Notificaciones de entrada/salida: {STATE}'
 claim_notify_state_enabled: '&aActivadas'
 claim_notify_state_disabled: '&cDesactivadas'
 
+# ------------------------------------------------------------
+# ✅ v1.2.6: Sistema de Notificaciones Mejorado
+# ------------------------------------------------------------
+notify_unavailable: '&cEl sistema de notificaciones no está disponible en este momento.'
+notify_greetings_enabled: '&a✔ Saludos activados. Ahora vas a ver mensajes de entrada y salida de parcelas.'
+notify_greetings_disabled: '&c✔ Saludos desactivados. Ya no vas a ver mensajes de entrada y salida de parcelas.'
+notify_admin_enabled: '&a✔ Notificaciones administrativas activadas. Ahora vas a recibir actualizaciones administrativas.'
+notify_admin_disabled: '&c✔ Notificaciones administrativas desactivadas. Las actualizaciones administrativas están ocultas.'
+notify_mode_set: '&a✔ Modo de notificación configurado en: {MODE}'
+notify_mode_usage: '&eUso: &7/aegis notify mode <chat|actionbar|title>\n&7Modos disponibles:\n&7- &bchat &8- &7Mensajes de chat estándar\n&7- &bactionbar &8- &7Notificaciones en la barra de acción (sobre hotbar)\n&7- &btitle &8- &7Notificaciones de título/subtítulo (centro de pantalla)'
+notify_mode_invalid: '&cModo inválido: &7{MODE}\n&eModos válidos: &7chat, actionbar, title'
+notify_status: '&e&l━━━━━━━━━ &6Configuración de Notificaciones &e&l━━━━━━━━━\n&7Saludos: {GREETINGS}\n&7Actualizaciones Admin: {ADMIN}\n&7Modo: {MODE}\n&e&l━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+notify_usage: '&eComandos de Notificación:\n&7/aegis notify &8- &7Alternar mensajes de saludo\n&7/aegis notify greetings &8- &7Alternar mensajes de entrada/salida\n&7/aegis notify admin &8- &7Alternar notificaciones administrativas\n&7/aegis notify mode <chat|actionbar|title> &8- &7Configurar estilo de notificación\n&7/aegis notify status &8- &7Ver configuración actual'
+
+# RolesGUI v1.2.6: Mensajes de Seguridad
+role_cannot_remove_self: '&c❌ No podés eliminarte a vos mismo como propietario de la parcela. Transferí la propiedad primero.'
+role_no_permission: '&c❌ No tenés permiso para modificar este miembro.'
+
 travel_system_disabled: '&cEl sistema de viaje está deshabilitado.'
 home_teleport_disabled: '&cEl teletransporte al hogar está deshabilitado.'
 leveling_disabled: '&cEl sistema de niveles está deshabilitado.'

--- a/src/main/java/com/aegisguard/lang/spanish_mx/system.yml
+++ b/src/main/java/com/aegisguard/lang/spanish_mx/system.yml
@@ -137,6 +137,24 @@ claim_notify_state_enabled: '&aActivadas'
 claim_notify_state_disabled: '&cDesactivadas'
 
 # -------------------------------------------------
+# ✅ v1.2.6: Sistema de Notificaciones Mejorado
+# -------------------------------------------------
+notify_unavailable: '&cEl sistema de notificaciones no está disponible en este momento.'
+notify_greetings_enabled: '&a✔ Saludos activados. Ahora verás mensajes de entrada y salida de parcelas.'
+notify_greetings_disabled: '&c✔ Saludos desactivados. Ya no verás mensajes de entrada y salida de parcelas.'
+notify_admin_enabled: '&a✔ Notificaciones administrativas activadas. Ahora recibirás actualizaciones administrativas.'
+notify_admin_disabled: '&c✔ Notificaciones administrativas desactivadas. Las actualizaciones administrativas ahora están ocultas.'
+notify_mode_set: '&a✔ Modo de notificación establecido en: {MODE}'
+notify_mode_usage: '&eUso: &7/aegis notify mode <chat|actionbar|title>\n&7Modos disponibles:\n&7- &bchat &8- &7Mensajes de chat estándar\n&7- &bactionbar &8- &7Notificaciones en la barra de acción (sobre hotbar)\n&7- &btitle &8- &7Notificaciones de título/subtítulo (centro de pantalla)'
+notify_mode_invalid: '&cModo inválido: &7{MODE}\n&eModos válidos: &7chat, actionbar, title'
+notify_status: '&e&l━━━━━━━━━ &6Configuración de Notificaciones &e&l━━━━━━━━━\n&7Saludos: {GREETINGS}\n&7Actualizaciones Admin: {ADMIN}\n&7Modo: {MODE}\n&e&l━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━'
+notify_usage: '&eComandos de Notificación:\n&7/aegis notify &8- &7Alternar mensajes de saludo\n&7/aegis notify greetings &8- &7Alternar mensajes de entrada/salida\n&7/aegis notify admin &8- &7Alternar notificaciones administrativas\n&7/aegis notify mode <chat|actionbar|title> &8- &7Establecer estilo de notificación\n&7/aegis notify status &8- &7Ver configuración actual'
+
+# RolesGUI v1.2.6: Mensajes de Seguridad
+role_cannot_remove_self: '&c❌ No puedes eliminarte a ti mismo como propietario de la parcela. Transfiere la propiedad primero.'
+role_no_permission: '&c❌ No tienes permiso para modificar este miembro.'
+
+# -------------------------------------------------
 # Protection Denies
 # -------------------------------------------------
 cannot_break: '&c❌ No puedes romper bloques aquí; esta área está protegida.'


### PR DESCRIPTION
Added Phase 2B notification system strings to all 5 language files in src/main/java/com/aegisguard/lang/ directory:

- notify_unavailable, notify_greetings_enabled, notify_greetings_disabled
- notify_admin_enabled, notify_admin_disabled, notify_mode_set
- notify_mode_usage, notify_mode_invalid, notify_status, notify_usage
- role_cannot_remove_self, role_no_permission

All strings localized appropriately:
- old_english: Old English style with þ/ð characters
- hybrid_english: Hybrid medieval/modern style
- modern_english: Contemporary English
- spanish_mx: Mexican Spanish (tú form)
- spanish_ar: Argentine Spanish (vos form)

https://claude.ai/code/session_01WHKWjGHRkCc2Qq6aRxQr8p